### PR TITLE
Run pipeline for changes in any subdirectories of $tf_root

### DIFF
--- a/.gitlab-ci/generate-ci-config-without-gopass.sh
+++ b/.gitlab-ci/generate-ci-config-without-gopass.sh
@@ -50,7 +50,7 @@ if [ "$PARENT_PIPELINE_SOURCE" != "schedule" ]; then
 	cat << EOT
   rules:
     - changes:
-        - "$tf_root/*"
+        - "$tf_root/**/*"
 EOT
 fi
 done

--- a/.gitlab-ci/generate-ci-config.sh
+++ b/.gitlab-ci/generate-ci-config.sh
@@ -68,7 +68,7 @@ if [ "$PARENT_PIPELINE_SOURCE" != "schedule" ]; then
 	cat << EOT
   rules:
     - changes:
-        - "$tf_root/*"
+        - "$tf_root/**/*"
 EOT
 fi
 done


### PR DESCRIPTION
We need to run the plan / apply if files in subdirectories change, for lambda functions, locally defined modules, etc. that are usually in subdirectories.
The only issue with this is for a repo that has standalone terraform "working directories"  below each other. This is a bit ugly a shouldn't happen IMHO, but it can exist. In that case, we could trigger too many plans / applies. That being said, if the terraform status is clean, it wouldn't be a big issue, except that the pipeline would take longer to execute than necessary.