### PR TITLE
allow to override TF_IMAGE_REPOSITORY & TF_IMAGE_TAG

### DIFF
--- a/.gitlab-ci/generate-ci-config-without-gopass.sh
+++ b/.gitlab-ci/generate-ci-config-without-gopass.sh
@@ -1,21 +1,21 @@
 #!/bin/sh
 
-cat << 'EOT'
+cat << EOT
 workflow:
   rules:
-    - if: $CI_MERGE_REQUEST_IID
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    - if: $PARENT_PIPELINE_SOURCE == "schedule"
+    - if: \$CI_MERGE_REQUEST_IID
+    - if: \$CI_COMMIT_BRANCH == \$CI_DEFAULT_BRANCH
+    - if: \$PARENT_PIPELINE_SOURCE == "schedule"
 
 variables:
-  PARENT_PIPELINE_ID: $CI_PIPELINE_ID
-  ROOT_PIPELINE_SOURCE: $ROOT_PIPELINE_SOURCE
-  TF_IMAGE_REPOSITORY: camptocamp/terraform
-  TF_IMAGE_TAG: 0.13.6
+  PARENT_PIPELINE_ID: \$CI_PIPELINE_ID
+  ROOT_PIPELINE_SOURCE: \$ROOT_PIPELINE_SOURCE
+  TF_IMAGE_REPOSITORY: ${TF_IMAGE_REPOSITORY:=camptocamp/terraform}
+  TF_IMAGE_TAG: ${TF_IMAGE_TAG:=0.13.6}
 
 .init-ssh: &init-ssh |
   mkdir -p ~/.ssh
-  echo $TERRAFORM_SSH_KEY id_rsa > ~/.ssh/id_rsa
+  echo \$TERRAFORM_SSH_KEY id_rsa > ~/.ssh/id_rsa
   chmod 0600 ~/.ssh/id_rsa
   ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
   cp -a ~/.ssh .

--- a/.gitlab-ci/generate-ci-config.sh
+++ b/.gitlab-ci/generate-ci-config.sh
@@ -10,8 +10,8 @@ workflow:
 variables:
   PARENT_PIPELINE_ID: $CI_PIPELINE_ID
   ROOT_PIPELINE_SOURCE: $ROOT_PIPELINE_SOURCE
-  TF_IMAGE_REPOSITORY: camptocamp/terraform
-  TF_IMAGE_TAG: 0.13.6
+  TF_IMAGE_REPOSITORY: ${TF_IMAGE_REPOSITORY:=camptocamp/terraform}
+  TF_IMAGE_TAG: ${$TF_IMAGE_TAG:=0.13.6}
 
 .init-gpg: &init-gpg |
   uid=$(bash -c 'gpg --with-colons --import-options import-show --import --quiet <(echo "$GPG_SECRET_KEY")'|grep ^uid:|sed -n 's/.*<\(.*\)>.*/\1/p')

--- a/.gitlab-ci/terraform-pipeline-without-gopass.yaml
+++ b/.gitlab-ci/terraform-pipeline-without-gopass.yaml
@@ -53,6 +53,7 @@ lint:
   before_script:
     - cd "$TF_ROOT"
   script:
+    - terraform version
     - terraform fmt
   rules:
     - if: $ROOT_PIPELINE_SOURCE == "schedule"

--- a/.gitlab-ci/terraform-pipeline.yaml
+++ b/.gitlab-ci/terraform-pipeline.yaml
@@ -53,6 +53,7 @@ lint:
   before_script:
     - cd "$TF_ROOT"
   script:
+    - terraform version
     - terraform fmt
   rules:
     - if: $ROOT_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION
We should be able to override the version (and repo) of the terraform image we want to use.

Currently the child pipelines don't honour the variables `TF_IMAGE_REPOSITORY` & `TF_IMAGE_TAG` without this proposed PR.

The gitlab documentation regarding variable precedence [1] is not so clear whether it's a bug or expected in our current use case.

[1] https://docs.gitlab.com/ee/ci/variables/#cicd-variable-precedence